### PR TITLE
add lint test for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+php:
+  - 7.0.8
+  - 5.6
+  - 5.5.9
+  - 5.3.3
+script:
+  - ./test.lint.bash

--- a/test.lint.bash
+++ b/test.lint.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+shopt -s globstar
+
+set -e
+
+for x in **/*php; do
+	php -l "$x";
+done


### PR DESCRIPTION
This is probably the most basic test that one can have in their suite - a syntax linter. This will catch all the simple parse errors.

Furthermore, I've included a travis yml file for [building in multiple different environments][1] so you can be sure of what works with which version. You should create a free account for open source projects and [set up the git hooks][2] with the main repository here.

[1]:https://travis-ci.org/ISYS4283/backpacker
[2]:https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A